### PR TITLE
fix new avr-gcc compile error : multiple definition of `ispTransmit'

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "       ISP=${ISP}"
 	@echo "       PORT=${PORT}"
 
-COMPILE = avr-gcc -Wall -O2 -Iusbdrv -I. -mmcu=$(TARGET) -DF_CPU=$(CLOCK) # -DDEBUG_LEVEL=2
+COMPILE = avr-gcc -Wall -fcommon -O2 -Iusbdrv -I. -mmcu=$(TARGET) -DF_CPU=$(CLOCK) # -DDEBUG_LEVEL=2
 
 OBJECTS = usbdrv/usbdrv.o usbdrv/usbdrvasm.o usbdrv/oddebug.o isp.o clock.o tpi.o main.o
 


### PR DESCRIPTION
Hi, @aleh

This PR will be fix error compile for newer avr-gcc.
Maybe this old repository but very useful because still so many usb-isp sold out there.